### PR TITLE
added authorized keys for semaphore

### DIFF
--- a/control-services/bin/setup.sh
+++ b/control-services/bin/setup.sh
@@ -251,30 +251,13 @@ source ~/.bashrc
 echo
 echo "ROUS configurations"
 tfvars_path=/home/control/rous/terraform/variables.auto.tfvars
-sem_path=/home/control/rous/tasks/group_vars/all/creds.yml
 ### ROUS ###
 if test -f /home/control/rous/terraform/variables.tfvars.example; then
     echo -n '' > $tfvars_path
-    mv /home/control/rous/tasks/group_vars/all/creds.example $sem_path
 
     while read tf_var; do
         if [[ $tf_var != "#"* ]] && [[ ! -z $tf_var ]]; then
             tfKey=`echo ${tf_var%=*} | cut -d' ' -f1`
-            currentSemKey=''
-
-            # find matching semaphore var
-            case $tfKey in
-                vsphere_user)
-                    currentSemKey="vsphereUsername"
-                    ;;
-                vsphere_password)
-                    currentSemKey="vspherePassword"
-                    ;;
-               *)
-                   currentSemKey=""
-                   ;;
-            esac
-
 
             echo "Default is" $tf_var
             read -p "change? Y/N " change_tf_option < /dev/tty
@@ -283,11 +266,6 @@ if test -f /home/control/rous/terraform/variables.tfvars.example; then
                 read -p "${tfKey} = " tfValue < /dev/tty
                 echo $tfKey = \"$tfValue\" >> $tfvars_path
 
-                # save new value for semaphore cred
-                if [[ ! -z $currentSemKey ]]; then
-                    echo "change"
-                    sed -i "s/$currentSemKey: .*/$currentSemKey: \"$tfValue\"/g" $sem_path
-                fi
             else
                 # save default var for terraform
                 echo $tf_var >> $tfvars_path

--- a/control-services/bin/setup.sh
+++ b/control-services/bin/setup.sh
@@ -255,7 +255,7 @@ sem_path=/home/control/rous/tasks/group_vars/all/creds.yml
 ### ROUS ###
 if test -f /home/control/rous/terraform/variables.tfvars.example; then
     echo -n '' > $tfvars_path
-    cat /home/control/rous/tasks/group_vars/all/creds.example > $sem_path
+    mv /home/control/rous/tasks/group_vars/all/creds.example $sem_path
 
     while read tf_var; do
         if [[ $tf_var != "#"* ]] && [[ ! -z $tf_var ]]; then
@@ -293,6 +293,7 @@ if test -f /home/control/rous/terraform/variables.tfvars.example; then
                 echo $tf_var >> $tfvars_path
             fi
         fi
+
     done < /home/control/rous/terraform/variables.tfvars.example
 fi
 

--- a/control-services/bin/setup.sh
+++ b/control-services/bin/setup.sh
@@ -91,10 +91,16 @@ echo "Checking for key at $SEMAPHORE_SSH_KEY_PATH"
 if test -f "$SEMAPHORE_SSH_KEY_PATH"; then
     echo
     echo "Key exists"
+    SEMVAR="$(cat $SSH_PATH/semaphore.pub)"
+    if [[ $(grep -c "$SEMVAR" $SSH_PATH/authorized_keys) -lt 1 ]]; then
+        echo "key is authorized"
+        cat $SSH_PATH/semaphore.pub >> $SSH_PATH/authorized_keys
+    fi
 else
     echo
     echo "Key does not exist"
     ssh-keygen -b 2048 -t rsa -f $SEMAPHORE_SSH_KEY_PATH -q -N ""
+    cat $SSH_PATH/semaphore.pub >> $SSH_PATH/authorized_keys
 fi
 
 # Create authorized keys with only the Semaphore key
@@ -260,7 +266,6 @@ if test -f /home/control/rous/terraform/variables.tfvars.example; then
             case $tfKey in
                 vsphere_user)
                     currentSemKey="vsphereUsername"
-                    echo "tis a match"
                     ;;
                 vsphere_password)
                     currentSemKey="vspherePassword"

--- a/control-services/cli/vater.py
+++ b/control-services/cli/vater.py
@@ -130,8 +130,8 @@ def access(config, args):
 
 
 def killTerraform(config, args):
-    savePIDs = "pgrep terraform | tee /tmp/pids"
-    killPIDs = "sudo kill $(cat /tmp/pids)"
+    savePIDs = "pgrep terraform | tee /tmp/pids > /dev/null"
+    killPIDs = "sudo kill -9 $(cat /tmp/pids)"
     if system("pgrep terraform") == 0:
         system(savePIDs)
         if system(killPIDs) == 0:


### PR DESCRIPTION
1. Semaphore was not able to run tasks such as "create falling star" since SSH would fail.
Adding the semaphore.pub to /home/control/.ssh/authorized_keys would allow semaphore to ssh seamlessly.
setup.sh expands upon this by appending the semaphore.pub if it doesn't exist in the authorized_keys.

2. Terraform hangs. Using `vater kill` defaults to SIG-TERM which is the 'nice' way of killing a process. However this gracious kill takes time and may fail. Changed to `kill -9` that will forcefully kill the terraform process. 