### PR TITLE
semaphore now builds

### DIFF
--- a/control-services/bin/configure_git.sh
+++ b/control-services/bin/configure_git.sh
@@ -166,7 +166,7 @@ git --git-dir $HOME/$CONFIG_REPO/.git pull origin main
 
 
 # Install dependencies for python
-sudo apt-get install python3 && sudo apt-get install python3-pip
+sudo apt-get install -y python3 && sudo apt-get install -y python3-pip
 pip install -r $HOME/$SETUP_REPO/requirements/requirements.txt
 
 ### DOCKER ###

--- a/control-services/bin/install_requirements.sh
+++ b/control-services/bin/install_requirements.sh
@@ -7,7 +7,6 @@ sudo apt-get upgrade -y
 
 # Install go, task, pkr for building semaphore
 sudo snap install go --channel=1.19/stable --classic
-#sudo snap install task --classic
 
 # Fix pathing to use go installed binaries
 export PATH=$PATH:$HOME/go/bin

--- a/control-services/bin/install_requirements.sh
+++ b/control-services/bin/install_requirements.sh
@@ -5,7 +5,7 @@ set -e
 sudo apt-get update -y
 sudo apt-get upgrade -y
 
-# Install go, task, pkr for building semaphore
+# Install go building semaphore
 sudo snap install go --channel=1.19/stable --classic
 
 # Fix pathing to use go installed binaries

--- a/control-services/bin/install_requirements.sh
+++ b/control-services/bin/install_requirements.sh
@@ -9,13 +9,13 @@ sudo apt-get upgrade -y
 sudo snap install go --channel=1.19/stable --classic
 
 # Fix pathing to use go installed binaries
-export PATH=$PATH:$HOME/go/bin
+export PATH=$PATH:$HOME/go/bin:/usr/local/go/bin
 # add to /etc/profile for persistence if it's not there already
-if [[ $(grep export /etc/profile) == *"/home/control/go/bin"* ]]; then
+if [[ $(grep export /etc/profile) == *"/home/control/go/bin:/usr/local/go/bin"* ]]; then
     echo "path to go binaries exists in /etc/profile"
 else
     sudo cp /etc/profile /etc/profile.backup
-    sudo sed -i sed "s%PATH=.\+%PATH=$PATH:$HOME/go/bin%g" /etc/profile
+    sudo sed -i "s%PATH=.\+%PATH=$PATH:$HOME/go/bin:/usr/local/go/bin%g" /etc/profile
 fi
 
 # Confirm go was installed and exported
@@ -57,7 +57,7 @@ sudo apt-get update && sudo apt-get install -y terraform
 sudo apt-get install -y wait-for-it
 
 # Install nginx
-sudo apt-get install nginx
+sudo apt-get install -y nginx
 sudo systemctl enable nginx
 sudo systemctl start nginx
 

--- a/control-services/bin/install_requirements.sh
+++ b/control-services/bin/install_requirements.sh
@@ -15,7 +15,7 @@ if [[ $(grep export /etc/profile) == *"/home/control/go/bin:/usr/local/go/bin"* 
     echo "path to go binaries exists in /etc/profile"
 else
     sudo cp /etc/profile /etc/profile.backup
-    sudo sed -i "s%PATH=.\+%PATH=$PATH:$HOME/go/bin:/usr/local/go/bin%g" /etc/profile
+    echo "export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin" | sudo tee -a /etc/profile
     sudo sed -i "s%/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin%/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/home/control/go/bin:/usr/local/go/bin%g" /etc/sudoers 
 fi
 

--- a/control-services/bin/install_requirements.sh
+++ b/control-services/bin/install_requirements.sh
@@ -16,6 +16,7 @@ if [[ $(grep export /etc/profile) == *"/home/control/go/bin:/usr/local/go/bin"* 
 else
     sudo cp /etc/profile /etc/profile.backup
     sudo sed -i "s%PATH=.\+%PATH=$PATH:$HOME/go/bin:/usr/local/go/bin%g" /etc/profile
+    sudo sed -i "s%/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin%/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/home/control/go/bin:/usr/local/go/bin%g" /etc/sudoers 
 fi
 
 # Confirm go was installed and exported

--- a/control-services/bin/install_requirements.sh
+++ b/control-services/bin/install_requirements.sh
@@ -5,8 +5,11 @@ set -e
 sudo apt-get update -y
 sudo apt-get upgrade -y
 
-# Install go building semaphore
-sudo snap install go --channel=1.19/stable --classic
+# Install go for building semaphore
+sudo rm -rf /usr/local/go
+wget https://go.dev/dl/go1.19.3.linux-amd64.tar.gz -P /tmp/
+sudo tar -C /usr/local/ -xzf /tmp/go1.19.3.linux-amd64.tar.gz
+sudo rm -f /tmp/go1.19.3.linux-amd64.tar.gz
 
 # Fix pathing to use go installed binaries
 export PATH=$PATH:$HOME/go/bin:/usr/local/go/bin

--- a/control-services/bin/install_requirements.sh
+++ b/control-services/bin/install_requirements.sh
@@ -5,26 +5,19 @@ set -e
 sudo apt-get update -y
 sudo apt-get upgrade -y
 
-# Install go for building semaphore
-sudo rm -rf /usr/local/go
+# Install go, task, pkr for building semaphore
+sudo snap install go --channel=1.19/stable --classic
+#sudo snap install task --classic
 
-# check machine type for arm support
-machineType=$(uname -m)
-if [[ $machineType == "x86_64" ]] || [[ $machineType == "amd64" ]]; then
-    wget https://go.dev/dl/go1.17.7.linux-amd64.tar.gz -P /tmp/
-    sudo tar -C /usr/local/ -xzf /tmp/go1.17.7.linux-amd64.tar.gz
-    rm -f /tmp/go1.17.7.linux-amd64.tar.gz
-elif [[ $machineType == "aarch64" ]] || [[ $machineType == "arm64" ]]; then
-    echo "WARNING: limited support for arm, press any key if you understand"
-    read -n 1 -s
-    wget https://go.dev/dl/go1.17.7.linux-arm64.tar.gz -P /tmp/
-    sudo tar -C /usr/local/ -xzf /tmp/go1.17.7.linux-arm64.tar.gz
-    rm -f /tmp/go1.17.7.linux-arm64.tar.gz
+# Fix pathing to use go installed binaries
+export PATH=$PATH:$HOME/go/bin
+# add to /etc/profile for persistence if it's not there already
+if [[ $(grep export /etc/profile) == *"/home/control/go/bin"* ]]; then
+    echo "path to go binaries exists in /etc/profile"
+else
+    sudo cp /etc/profile /etc/profile.backup
+    sudo sed -i sed "s%PATH=.\+%PATH=$PATH:$HOME/go/bin%g" /etc/profile
 fi
-
-echo "export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin" | sudo tee -a /etc/profile
-sudo sed -i s@/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin@/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/usr/local/go/bin:$HOME/go/bin@g /etc/sudoers
-source /etc/profile
 
 # Confirm go was installed and exported
 go version
@@ -50,11 +43,7 @@ sudo systemctl enable docker
 sudo systemctl start docker
 
 # Install docker-compose
-if [[ $machineType == "x86_64" ]] || [[ $machineType == "amd64" ]];then
-    sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-elif [[ $machineType == "aarch64" ]]|| [[ $machineType == "arm64" ]]; then
-    sudo curl -L "https://github.com/docker/compose/releases/download/v2.6.1/docker-compose-linux-aarch64" -o /usr/local/bin/docker-compose
-fi
+sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 
 # Point to hashicorp repo and install terraform and packer
@@ -63,16 +52,7 @@ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
 sudo apt-add-repository -y "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
 sudo apt-get update && sudo apt-get install -y packer
 
-if [[ $machineType == "x86_64" ]] || [[ $machineType == "amd64" ]]; then
-    sudo apt-get update && sudo apt-get install -y terraform
-elif [[ $machineType == "aarch64" ]]|| [[ $machineType == "arm64" ]]; then
-    wget https://releases.hashicorp.com/terraform/1.2.5/terraform_1.2.5_linux_arm64.zip -P /tmp/
-    sudo apt install -y unzip
-    sudo unzip /tmp/terraform_1.2.5_linux_arm64.zip -d /usr/local/
-    echo "export PATH=$PATH:/usr/local/terraform:$HOME/terraform" | sudo tee -a /etc/profile
-    sudo sed -i s@/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/usr/local/go/bin:$HOME/go/bin@/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/usr/local/go/bin:$HOME/go/bin:/usr/local/terraform@g /etc/sudoers
-    source /etc/profile
-fi
+sudo apt-get update && sudo apt-get install -y terraform
 
 # Install a tool used in start script
 sudo apt-get install -y wait-for-it

--- a/control-services/cli/semaphore.py
+++ b/control-services/cli/semaphore.py
@@ -109,18 +109,17 @@ class Semaphore:
         # Must have gcc added as part of the image when docker is being built
         # Alpine does not have gcc by default
         cmd = [
-                "sed",
-                "-i",
-                "s/-U libc-dev/-U libc-dev build-base/",
-                self.cfg["semaphore"]["build"]["source_dir"] + "deployment/docker/prod/Dockerfile",
+            "sed",
+            "-i",
+            "s/-U libc-dev/-U libc-dev build-base/",
+            self.cfg["semaphore"]["build"]["source_dir"]
+            + "deployment/docker/prod/Dockerfile",
         ]
         subprocess.check_output(
-                cmd,
-                universal_newlines=True,
-                cwd=self.cfg["semaphore"]["build"]["source_dir"],
+            cmd,
+            universal_newlines=True,
+            cwd=self.cfg["semaphore"]["build"]["source_dir"],
         )
-
-
 
         # Build image
         cmd = ["sudo", "context=prod", "tag=dynamicVars", "task", "docker:build"]

--- a/control-services/cli/semaphore.py
+++ b/control-services/cli/semaphore.py
@@ -105,6 +105,23 @@ class Semaphore:
             cwd=self.cfg["semaphore"]["build"]["source_dir"],
         )
 
+        # Fix rmfirth/semaphore bug in their Dockerfile
+        # Must have gcc added as part of the image when docker is being built
+        # Alpine does not have gcc by default
+        cmd = [
+                "sed",
+                "-i",
+                "s/-U libc-dev/-U libc-dev build-base/",
+                self.cfg["semaphore"]["build"]["source_dir"] + "deployment/docker/prod/Dockerfile",
+        ]
+        subprocess.check_output(
+                cmd,
+                universal_newlines=True,
+                cwd=self.cfg["semaphore"]["build"]["source_dir"],
+        )
+
+
+
         # Build image
         cmd = ["sudo", "context=prod", "tag=dynamicVars", "task", "docker:build"]
 


### PR DESCRIPTION
1. updated how go was being installed, ensured path was updated in /etc/profile if the path to the binaries wasn't there
2. added `build-base` to dockerfile for semaphore from rmfirth cherrypick branch

Tested on ducknet
- stopped all processes with `sudo docker stop $(sudo docker ps -aq)`
- removed all images with `sudo docker rmi -rf $(sudo docker images -aq)`
- removed all volumes with `sudo rm -rf /home/control/vater/control-services/data`
- cleanup with `vater clean`
- performed `vater restart` and waited until everything was rebuilt and could access the semaphore website and see templates